### PR TITLE
Add Redis server example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,5 +4,5 @@
 * License: Apache-2.0 License
 * Required Java version: Java 11
 * Maven coordinates:
-** `io.netty.contrib:netty-codec-redis:5.0.0.Final-SNAPSHOT`
+** `io.netty.contrib:netty-codec-redis:4.1.92.Final-SNAPSHOT`
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -7,14 +7,14 @@
     <parent>
         <groupId>io.netty.contrib</groupId>
         <artifactId>netty-codec-redis-parent</artifactId>
-        <version>5.0.0.Final-SNAPSHOT</version>
+        <version>4.1.92.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-codec-redis-benchmarks</artifactId>
     <version>${parent.version}</version>
 
     <properties>
-        <jmh.version>1.33</jmh.version>
+        <jmh.version>1.36</jmh.version>
     </properties>
 
     <build>

--- a/benchmarks/src/main/java/io/netty/contrib/microbenchmarks/redis/package-info.java
+++ b/benchmarks/src/main/java/io/netty/contrib/microbenchmarks/redis/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,6 +14,6 @@
  * under the License.
  */
 /**
- * Benchmarks for {@link io.netty.contrib.handler.codec.redis}.
+ * Benchmarks for {@link io.netty.handler.codec.redis}.
  */
 package io.netty.contrib.microbenchmarks.redis;

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -7,10 +7,10 @@
     <parent>
         <groupId>io.netty.contrib</groupId>
         <artifactId>netty-codec-redis-parent</artifactId>
-        <version>5.0.0.Final-SNAPSHOT</version>
+        <version>4.1.92.Final-SNAPSHOT</version>
     </parent>
 
-    <artifactId>codec-redis</artifactId>
+    <artifactId>netty-codec-redis</artifactId>
     <version>${parent.version}</version>
     <name>Netty/Codec/Redis</name>
     <packaging>jar</packaging>

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/AbstractStringRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/AbstractStringRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,10 +12,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
-import static java.util.Objects.requireNonNull;
-
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
@@ -28,7 +28,7 @@ public abstract class AbstractStringRedisMessage implements RedisMessage {
     private final String content;
 
     AbstractStringRedisMessage(String content) {
-        this.content = requireNonNull(content, "content");
+        this.content = ObjectUtil.checkNotNull(content, "content");
     }
 
     /**
@@ -48,4 +48,5 @@ public abstract class AbstractStringRedisMessage implements RedisMessage {
                 .append(content)
                 .append(']').toString();
     }
+
 }

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/ArrayHeaderRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/ArrayHeaderRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.util.internal.StringUtil;
@@ -30,7 +31,7 @@ public class ArrayHeaderRedisMessage implements RedisMessage {
      */
     public ArrayHeaderRedisMessage(long length) {
         if (length < RedisConstants.NULL_VALUE) {
-            throw new RedisCodecException("length: " + length + " (expected: >= " + RedisConstants.NULL_VALUE + ')');
+            throw new RedisCodecException("length: " + length + " (expected: >= " + RedisConstants.NULL_VALUE + ")");
         }
         this.length = length;
     }

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/ArrayRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/ArrayRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,17 +12,17 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
-
-import static java.util.Objects.requireNonNull;
-
-import io.netty.util.AbstractReferenceCounted;
-import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.Collections;
 import java.util.List;
+
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
 
 /**
  * Arrays of <a href="https://redis.io/topics/protocol">RESP</a>.
@@ -43,7 +43,7 @@ public class ArrayRedisMessage extends AbstractReferenceCounted implements Redis
      */
     public ArrayRedisMessage(List<RedisMessage> children) {
         // do not retain here. children are already retained when created.
-        this.children = requireNonNull(children, "children");
+        this.children = ObjectUtil.checkNotNull(children, "children");
     }
 
     /**
@@ -173,4 +173,5 @@ public class ArrayRedisMessage extends AbstractReferenceCounted implements Redis
             return "EmptyArrayRedisMessage";
         }
     };
+
 }

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/BulkStringHeaderRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/BulkStringHeaderRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.util.internal.UnstableApi;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/BulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/BulkStringRedisContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/DefaultBulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/DefaultBulkStringRedisContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/DefaultLastBulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/DefaultLastBulkStringRedisContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/ErrorRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/ErrorRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.util.internal.UnstableApi;
@@ -30,4 +31,5 @@ public final class ErrorRedisMessage extends AbstractStringRedisMessage {
     public ErrorRedisMessage(String content) {
         super(content);
     }
+
 }

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/FixedRedisMessagePool.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/FixedRedisMessagePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,7 +12,11 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -20,10 +24,6 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.collection.LongObjectHashMap;
 import io.netty.util.collection.LongObjectMap;
 import io.netty.util.internal.UnstableApi;
-
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A default fixed redis message pool.
@@ -94,9 +94,9 @@ public final class FixedRedisMessagePool implements RedisMessagePool {
      * Creates a {@link FixedRedisMessagePool} instance.
      */
     private FixedRedisMessagePool() {
-        keyToSimpleStrings = new EnumMap<RedisReplyKey, SimpleStringRedisMessage>(RedisReplyKey.class);
-        stringToSimpleStrings = new HashMap<>(RedisReplyKey.values().length, 1.0f);
-        byteBufToSimpleStrings = new HashMap<>(RedisReplyKey.values().length, 1.0f);
+        keyToSimpleStrings = new HashMap<RedisReplyKey, SimpleStringRedisMessage>(RedisReplyKey.values().length, 1.0f);
+        stringToSimpleStrings = new HashMap<String, SimpleStringRedisMessage>(RedisReplyKey.values().length, 1.0f);
+        byteBufToSimpleStrings = new HashMap<ByteBuf, SimpleStringRedisMessage>(RedisReplyKey.values().length, 1.0f);
         for (RedisReplyKey value : RedisReplyKey.values()) {
             ByteBuf key = Unpooled.unreleasableBuffer(Unpooled.wrappedBuffer(
                 value.name().getBytes(CharsetUtil.UTF_8))).asReadOnly();
@@ -107,9 +107,9 @@ public final class FixedRedisMessagePool implements RedisMessagePool {
             byteBufToSimpleStrings.put(key, message);
         }
 
-        keyToErrors = new EnumMap<RedisErrorKey, ErrorRedisMessage>(RedisErrorKey.class);
-        stringToErrors = new HashMap<>(RedisErrorKey.values().length, 1.0f);
-        byteBufToErrors = new HashMap<>(RedisErrorKey.values().length, 1.0f);
+        keyToErrors = new HashMap<RedisErrorKey, ErrorRedisMessage>(RedisErrorKey.values().length, 1.0f);
+        stringToErrors = new HashMap<String, ErrorRedisMessage>(RedisErrorKey.values().length, 1.0f);
+        byteBufToErrors = new HashMap<ByteBuf, ErrorRedisMessage>(RedisErrorKey.values().length, 1.0f);
         for (RedisErrorKey value : RedisErrorKey.values()) {
             ByteBuf key = Unpooled.unreleasableBuffer(Unpooled.wrappedBuffer(
                 value.toString().getBytes(CharsetUtil.UTF_8))).asReadOnly();
@@ -120,9 +120,9 @@ public final class FixedRedisMessagePool implements RedisMessagePool {
             byteBufToErrors.put(key, message);
         }
 
-        byteBufToIntegers = new HashMap<>(SIZE_CACHED_INTEGER_NUMBER, 1.0f);
-        longToIntegers = new LongObjectHashMap<>(SIZE_CACHED_INTEGER_NUMBER, 1.0f);
-        longToByteBufs = new LongObjectHashMap<>(SIZE_CACHED_INTEGER_NUMBER, 1.0f);
+        byteBufToIntegers = new HashMap<ByteBuf, IntegerRedisMessage>(SIZE_CACHED_INTEGER_NUMBER, 1.0f);
+        longToIntegers = new LongObjectHashMap<IntegerRedisMessage>(SIZE_CACHED_INTEGER_NUMBER, 1.0f);
+        longToByteBufs = new LongObjectHashMap<byte[]>(SIZE_CACHED_INTEGER_NUMBER, 1.0f);
         for (long value = MIN_CACHED_INTEGER_NUMBER; value < MAX_CACHED_INTEGER_NUMBER; value++) {
             byte[] keyBytes = RedisCodecUtil.longToAsciiBytes(value);
             ByteBuf keyByteBuf = Unpooled.unreleasableBuffer(Unpooled.wrappedBuffer(keyBytes)).asReadOnly();

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/FullBulkStringRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/FullBulkStringRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/InlineCommandRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/InlineCommandRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.util.internal.UnstableApi;
@@ -30,4 +31,5 @@ public final class InlineCommandRedisMessage extends AbstractStringRedisMessage 
     public InlineCommandRedisMessage(String content) {
         super(content);
     }
+
 }

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/IntegerRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/IntegerRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.util.internal.StringUtil;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/LastBulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/LastBulkStringRedisContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisBulkStringAggregator.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisBulkStringAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisCodecException.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisCodecException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.handler.codec.CodecException;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisCodecUtil.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisCodecUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.util.CharsetUtil;
@@ -34,7 +35,7 @@ final class RedisCodecUtil {
      */
     static short makeShort(char first, char second) {
         return PlatformDependent.BIG_ENDIAN_NATIVE_ORDER ?
-                (short) (second << 8 | first) : (short) (first << 8 | second);
+                (short) ((second << 8) | first) : (short) ((first << 8) | second);
     }
 
     /**
@@ -43,10 +44,10 @@ final class RedisCodecUtil {
     static byte[] shortToBytes(short value) {
         byte[] bytes = new byte[2];
         if (PlatformDependent.BIG_ENDIAN_NATIVE_ORDER) {
-            bytes[1] = (byte) (value >> 8 & 0xff);
+            bytes[1] = (byte) ((value >> 8) & 0xff);
             bytes[0] = (byte) (value & 0xff);
         } else {
-            bytes[0] = (byte) (value >> 8 & 0xff);
+            bytes[0] = (byte) ((value >> 8) & 0xff);
             bytes[1] = (byte) (value & 0xff);
         }
         return bytes;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisConstants.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 /**

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisEncoder.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,9 +12,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
-import static java.util.Objects.requireNonNull;
+import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -22,9 +23,8 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
-
-import java.util.List;
 
 /**
  * Encodes {@link RedisMessage} into bytes following
@@ -47,7 +47,7 @@ public class RedisEncoder extends MessageToMessageEncoder<RedisMessage> {
      * @param messagePool the predefined message pool.
      */
     public RedisEncoder(RedisMessagePool messagePool) {
-        this.messagePool = requireNonNull(messagePool, "messagePool");
+        this.messagePool = ObjectUtil.checkNotNull(messagePool, "messagePool");
     }
 
     @Override

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.util.internal.UnstableApi;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisMessagePool.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisMessagePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;
@@ -21,6 +22,7 @@ import io.netty.util.internal.UnstableApi;
  * A strategy interface for caching {@link RedisMessage}s.
  */
 @UnstableApi
+
 public interface RedisMessagePool {
 
     /**

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisMessageType.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/RedisMessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/SimpleStringRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/SimpleStringRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.netty.contrib.handler.codec.redis;
 
 import io.netty.util.internal.UnstableApi;
@@ -30,4 +31,5 @@ public final class SimpleStringRedisMessage extends AbstractStringRedisMessage {
     public SimpleStringRedisMessage(String content) {
         super(content);
     }
+
 }

--- a/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/package-info.java
+++ b/codec-redis/src/main/java/io/netty/contrib/handler/codec/redis/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.netty.contrib</groupId>
         <artifactId>netty-codec-redis-parent</artifactId>
-        <version>5.0.0.Final-SNAPSHOT</version>
+        <version>4.1.92.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-codec-redis-examples</artifactId>

--- a/examples/src/main/java/io/netty/contrib/handler/codec/redis/example/RedisClientHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/redis/example/RedisClientHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,9 +16,13 @@
 
 package io.netty.contrib.handler.codec.redis.example;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.netty.buffer.ByteBufUtil;
-import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.CodecException;
 import io.netty.contrib.handler.codec.redis.ArrayRedisMessage;
 import io.netty.contrib.handler.codec.redis.ErrorRedisMessage;
@@ -28,25 +32,21 @@ import io.netty.contrib.handler.codec.redis.RedisMessage;
 import io.netty.contrib.handler.codec.redis.SimpleStringRedisMessage;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * An example Redis client handler. This handler read input from STDIN and write output to STDOUT.
  */
-public class RedisClientHandler implements ChannelHandler {
+public class RedisClientHandler extends ChannelDuplexHandler {
 
     @Override
-    public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         String[] commands = ((String) msg).split("\\s+");
-        List<RedisMessage> children = new ArrayList<>(commands.length);
+        List<RedisMessage> children = new ArrayList<RedisMessage>(commands.length);
         for (String cmdString : commands) {
             children.add(new FullBulkStringRedisMessage(ByteBufUtil.writeUtf8(ctx.alloc(), cmdString)));
         }
         RedisMessage request = new ArrayRedisMessage(children);
-        return ctx.write(request);
+        ctx.write(request, promise);
     }
 
     @Override

--- a/examples/src/main/java/io/netty/contrib/handler/codec/redis/example/RedisServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/redis/example/RedisServer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.handler.codec.redis.example;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.contrib.handler.codec.redis.RedisArrayAggregator;
+import io.netty.contrib.handler.codec.redis.RedisBulkStringAggregator;
+import io.netty.contrib.handler.codec.redis.RedisDecoder;
+import io.netty.contrib.handler.codec.redis.RedisEncoder;
+
+public final class RedisServer {
+
+    private static final int PORT = Integer.parseInt(System.getProperty("port", "6379"));
+
+    public static void main(String[] args) throws Exception {
+        final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        final EventLoopGroup workerGroup = new NioEventLoopGroup();
+
+        // This latch will become zero once `RedisServerHandler` receives a SHUTDOWN command.
+        final CountDownLatch shutdownLatch = new CountDownLatch(1);
+        final ConcurrentMap<String, String> map = new ConcurrentHashMap<>();
+
+        try {
+            final ServerBootstrap b = new ServerBootstrap();
+            b.channel(NioServerSocketChannel.class);
+            b.group(bossGroup, workerGroup);
+            b.childHandler(new ChannelInitializer<SocketChannel>() {
+                @Override
+                protected void initChannel(SocketChannel ch) throws Exception {
+                    final ChannelPipeline p = ch.pipeline();
+                    p.addLast(new RedisDecoder());
+                    p.addLast(new RedisBulkStringAggregator());
+                    p.addLast(new RedisArrayAggregator());
+                    p.addLast(new RedisEncoder());
+                    p.addLast(new RedisServerHandler(map, shutdownLatch));
+                }
+            });
+            final Channel ch = b.bind(PORT).sync().channel();
+            System.err.println("An example Redis server now listening at " + ch.localAddress() + " ..");
+
+            // Wait until the latch becomes zero.
+            shutdownLatch.await();
+            System.err.println("Received a SHUTDOWN command; shutting down ..");
+        } finally {
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+
+    private RedisServer() {}
+}

--- a/examples/src/main/java/io/netty/contrib/handler/codec/redis/example/RedisServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/redis/example/RedisServerHandler.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.handler.codec.redis.example;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.contrib.handler.codec.redis.ArrayRedisMessage;
+import io.netty.contrib.handler.codec.redis.ErrorRedisMessage;
+import io.netty.contrib.handler.codec.redis.FullBulkStringRedisMessage;
+import io.netty.contrib.handler.codec.redis.IntegerRedisMessage;
+import io.netty.contrib.handler.codec.redis.RedisMessage;
+import io.netty.contrib.handler.codec.redis.SimpleStringRedisMessage;
+import io.netty.util.ReferenceCountUtil;
+
+final class RedisServerHandler extends ChannelInboundHandlerAdapter {
+
+    private final ConcurrentMap<String, String> map;
+    private final CountDownLatch shutdownLatch;
+
+    RedisServerHandler(ConcurrentMap<String, String> map, CountDownLatch shutdownLatch) {
+        this.map = map;
+        this.shutdownLatch = shutdownLatch;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        try {
+            if (!(msg instanceof ArrayRedisMessage)) {
+                rejectMalformedRequest(ctx);
+                return;
+            }
+
+            final ArrayRedisMessage req = (ArrayRedisMessage) msg;
+            final List<RedisMessage> args = req.children();
+            for (RedisMessage a : args) {
+                if (!(a instanceof FullBulkStringRedisMessage)) {
+                    rejectMalformedRequest(ctx);
+                    return;
+                }
+            }
+
+            // For simplicity, convert all arguments into strings.
+            // In a real server, you need to handle them as they are or convert to byte[].
+            final List<String> strArgs =
+                    args.stream()
+                        .map(a -> {
+                            final FullBulkStringRedisMessage bulkStr = (FullBulkStringRedisMessage) a;
+                            if (!bulkStr.isNull()) {
+                                return bulkStr.content().toString(StandardCharsets.UTF_8);
+                            } else {
+                                return null;
+                            }
+                        })
+                        .collect(Collectors.toList());
+
+            System.err.println(ctx.channel() + " RCVD: " + strArgs);
+
+            final String command = strArgs.get(0);
+            switch (command) {
+                case "COMMAND":
+                    ctx.writeAndFlush(ArrayRedisMessage.EMPTY_INSTANCE);
+                    break;
+                case "GET": {
+                    handleGet(ctx, strArgs);
+                    break;
+                }
+                case "SET": {
+                    handleSet(ctx, strArgs);
+                    break;
+                }
+                case "DEL": {
+                    handleDel(ctx, strArgs);
+                    break;
+                }
+                case "SHUTDOWN":
+                    ctx.writeAndFlush(new SimpleStringRedisMessage("OK"))
+                       .addListener((ChannelFutureListener) f -> {
+                           shutdownLatch.countDown();
+                       });
+                    break;
+                default:
+                    reject(ctx, "ERR Unsupported command");
+            }
+        } finally {
+            ReferenceCountUtil.release(msg);
+        }
+    }
+
+    private void handleGet(ChannelHandlerContext ctx, List<String> strArgs) {
+        if (strArgs.size() < 2) {
+            reject(ctx, "ERR A GET command requires a key argument.");
+            return;
+        }
+
+        final String key = strArgs.get(1);
+        if (key == null) {
+            rejectNilKey(ctx);
+            return;
+        }
+
+        final String value = map.get(key);
+        final FullBulkStringRedisMessage reply;
+        if (value != null) {
+            reply = newBulkStringMessage(value);
+        } else {
+            reply = FullBulkStringRedisMessage.NULL_INSTANCE;
+        }
+
+        ctx.writeAndFlush(reply);
+    }
+
+    private void handleSet(ChannelHandlerContext ctx, List<String> strArgs) {
+        if (strArgs.size() < 3) {
+            reject(ctx, "ERR A GET command requires a key argument.");
+            return;
+        }
+        final String key = strArgs.get(1);
+        final String value = strArgs.get(2);
+        if (key == null) {
+            rejectNilKey(ctx);
+            return;
+        }
+        if (value == null) {
+            reject(ctx, "ERR A nil value is not allowed.");
+            return;
+        }
+
+        // Very naive simple detection of 'GET' option.
+        // Note that we don't support other options which might appear before
+        // the 'GET' option in reality.
+        final boolean shouldReplyOldValue =
+                strArgs.size() > 3 && "GET".equals(strArgs.get(3));
+
+        final String oldValue = map.put(key, value);
+        final RedisMessage reply;
+        if (shouldReplyOldValue) {
+            if (oldValue != null) {
+                reply = newBulkStringMessage(oldValue);
+            } else {
+                reply = FullBulkStringRedisMessage.NULL_INSTANCE;
+            }
+        } else {
+            reply = new SimpleStringRedisMessage("OK");
+        }
+
+        ctx.writeAndFlush(reply);
+    }
+
+    private void handleDel(ChannelHandlerContext ctx, List<String> strArgs) {
+        if (strArgs.size() < 2) {
+            reject(ctx, "ERR A DEL command requires at least one key argument.");
+            return;
+        }
+        int removedEntries = 0;
+        for (int i = 1; i < strArgs.size(); i++) {
+            final String key = strArgs.get(i);
+            if (key == null) {
+                continue;
+            }
+            if (map.remove(key) != null) {
+                removedEntries++;
+            }
+        }
+
+        ctx.writeAndFlush(new IntegerRedisMessage(removedEntries));
+    }
+
+    private static FullBulkStringRedisMessage newBulkStringMessage(String oldValue) {
+        return new FullBulkStringRedisMessage(
+                Unpooled.copiedBuffer(oldValue, StandardCharsets.UTF_8));
+    }
+
+    private static void rejectMalformedRequest(ChannelHandlerContext ctx) {
+        reject(ctx, "ERR Client request bust be an array of bulk strings.");
+    }
+
+    private static void rejectNilKey(ChannelHandlerContext ctx) {
+        reject(ctx, "ERR A nil key is not allowed.");
+    }
+
+    private static void reject(ChannelHandlerContext ctx, String error) {
+        ctx.writeAndFlush(new ErrorRedisMessage(error));
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        System.err.println("Unexpected exception handling " + ctx.channel());
+        cause.printStackTrace(System.err);
+        ctx.close();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>io.netty.contrib</groupId>
   <artifactId>netty-codec-redis-parent</artifactId>
-  <version>5.0.0.Final-SNAPSHOT</version>
+  <version>4.1.92.Final-SNAPSHOT</version>
   <name>Netty/Codec/Redis Parent</name>
   <packaging>pom</packaging>
   <url>https://netty.io/</url>
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.0.Final-SNAPSHOT</netty.version>
+    <netty.version>4.1.92.Final-SNAPSHOT</netty.version>
     <netty.build.version>29</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

- We have a Redis client example, but not its server counterpart.
- This repository is not very usable at its current form because it depends on Netty 5.0.0.Final-SNAPSHOT which is actually very outdated.

Modifications:

- Revert the repository to use Netty 4.1.
- Add `RedisServer` and `RedisServerHandler` which demonstrate how to write a server that understands RESP.
  - Currently supports GET, SET, DEL and SHUTDOWN command in a very simplistic form.

Result:

- This repository now builds without failure.
- This repository now uses the Netty version that's actually up to date.
- We now have a Redis server example, as well as a client-side one.